### PR TITLE
Ensure scraper.rb passes rubocop

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -44,7 +44,9 @@ class WinnerRow < Scraped::HTML
 
   field :source do
     # wrong link on site!
-    return 'http://www.caribbeanelections.com/vc/election2015/candidates/Frederick_Stephenson.asp' if area == 'South Windward'
+    if area == 'South Windward'
+      return 'http://www.caribbeanelections.com/vc/election2015/candidates/Frederick_Stephenson.asp'
+    end
     tds[2].css('a/@href').text
   end
 
@@ -63,7 +65,7 @@ class MemberPage < Scraped::HTML
   end
 
   field :name do
-    name_td.text.gsub('*', '')
+    name_td.text.delete('*')
   end
 
   field :image do


### PR DESCRIPTION
`scraped.rb` is currently failing rubocop. This means all other PRs based off master will fail until the file is fixed.

This PR ensures that the file passes.